### PR TITLE
Updated Rails install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,10 @@ gem 'sass-rails', '>= 3.2'
 Import Bootstrap styles in `app/assets/stylesheets/application.scss`:
 
 ```scss
-// "bootstrap-sprockets" must be imported before "bootstrap" and "bootstrap/variables"
-@import "bootstrap-sprockets";
 @import "bootstrap";
 ```
 
-`bootstrap-sprockets` must be imported before `bootstrap` for the icon fonts to work.
+Note: Since Bootstrap 4 no longer includes glyphicons, boostrap-sprockets is no longer needed.
 
 Make sure the file has `.scss` extension (or `.sass` for Sass syntax). If you have just generated a new Rails app,
 it may come with a `.css` file instead. If this file exists, it will be served instead of Sass, so rename it:
@@ -52,13 +50,8 @@ Require Bootstrap Javascripts in `app/assets/javascripts/application.js`:
 
 ```js
 //= require jquery
-//= require bootstrap-sprockets
+//= require bootstrap
 ```
-
-`bootstrap-sprockets` and `bootstrap` [should not both be included](https://github.com/twbs/bootstrap-sass/issues/829#issuecomment-75153827) in `application.js`.
-
-`bootstrap-sprockets` provides individual Bootstrap Javascript files (`alert.js` or `dropdown.js`, for example), while
-`bootstrap` provides a concatenated file containing all Bootstrap Javascripts.
 
 #### Bower with Rails
 


### PR DESCRIPTION
I know that they are planning a separate gem for bootstrap 4, but I wanted to get started with Bootstrap 4 in rails. I used your updated branch to install bootstrap 4 (thanks!). I just updated the install instructions for Rails. My only question would be if you would `include bootstrap-sprockets` in the application.js file. I just included `bootstrap` and it is working, since we don't need sprockets for glyphicons that are not in Bootstrap 4.  Does `bootstrap-sprockets' js file give us anything extra?

Anyway, I hope the updated rails install instructions help as this gets merged into a new gem for bootstrap-4.